### PR TITLE
Add datadog tags.

### DIFF
--- a/extra/run-dogstatsd.sh
+++ b/extra/run-dogstatsd.sh
@@ -7,6 +7,10 @@ else
   exit 1
 fi
 
+if [[ $DATADOG_TAGS ]]; then
+  sed -i -e "s/^.*tags:.*$/tags: ${DATADOG_TAGS}/" /app/.apt/opt/datadog-agent/agent/datadog.conf
+fi
+
 if [[ $HEROKU_APP_NAME ]]; then
   sed -i -e "s/^.*hostname:.*$/hostname: ${HEROKU_APP_NAME}/" /app/.apt/opt/datadog-agent/agent/datadog.conf
 else


### PR DESCRIPTION
Adds datadog tags to the data being collected.

This adds the `tags: <key>:<value>` to the `datadog.conf`, similar to the `api_key`.

Tags are key/value pairs separated by commas and are optional.